### PR TITLE
feat(dbgap): remove datastage refs, support expanding SRA details, pa…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,41 @@
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install pipenv
+      run: |
+        echo installing pipenv
+        curl https://raw.githubusercontent.com/kennethreitz/pipenv/master/get-pipenv.py | python || pip install pipenv
+    - name: Install depenedencies
+      run: |
+        echo installing deps using pipenv
+        pipenv install --dev
+    - name: Running tests
+      run: |
+        echo installing deps using pipenv
+        pipenv run python -m pytest tests.py
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,5 +37,5 @@ jobs:
     - name: Running tests
       run: |
         echo installing deps using pipenv
-        pipenv run python -m pytest tests.py
+        pipenv run python -m pytest tests.py -vv
 

--- a/Pipfile
+++ b/Pipfile
@@ -10,4 +10,4 @@ pytest = "*"
 requests = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "709d6c9b8b40b9c586c6a134746efd6158d84be9da4cac15c25e8f49cb26cdc5"
+            "sha256": "03f05e808d849011739499ce042685cadfd6f14f4c6784ee3e6ad577b656437a"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.6"
         },
         "sources": [
             {
@@ -18,10 +18,10 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
-                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
+                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
+                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
             ],
-            "version": "==2019.9.11"
+            "version": "==2019.11.28"
         },
         "chardet": {
             "hashes": [
@@ -32,35 +32,28 @@
         },
         "idna": {
             "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
-            "version": "==2.8"
+            "version": "==2.9"
         },
         "requests": {
             "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
+                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
             ],
             "index": "pypi",
-            "version": "==2.22.0"
+            "version": "==2.23.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
-                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
             ],
-            "version": "==1.25.7"
+            "version": "==1.25.8"
         }
     },
     "develop": {
-        "atomicwrites": {
-            "hashes": [
-                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
-                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
-            ],
-            "version": "==1.3.0"
-        },
         "attrs": {
             "hashes": [
                 "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
@@ -70,75 +63,75 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26",
-                "sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"
+                "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302",
+                "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==0.23"
+            "version": "==1.5.0"
         },
         "more-itertools": {
             "hashes": [
-                "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
-                "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
+                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
+                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
             ],
-            "version": "==7.2.0"
+            "version": "==8.2.0"
         },
         "packaging": {
             "hashes": [
-                "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
-                "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"
+                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
+                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
             ],
-            "version": "==19.2"
+            "version": "==20.3"
         },
         "pluggy": {
             "hashes": [
-                "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6",
-                "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
-            "version": "==0.13.0"
+            "version": "==0.13.1"
         },
         "py": {
             "hashes": [
-                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
-                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
+                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
+                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
             ],
-            "version": "==1.8.0"
+            "version": "==1.8.1"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f",
-                "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"
+                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
+                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
             ],
-            "version": "==2.4.5"
+            "version": "==2.4.6"
         },
         "pytest": {
             "hashes": [
-                "sha256:8e256fe71eb74e14a4d20a5987bb5e1488f0511ee800680aaedc62b9358714e8",
-                "sha256:ff0090819f669aaa0284d0f4aad1a6d9d67a6efdc6dd4eb4ac56b704f890a0d6"
+                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
+                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
             ],
             "index": "pypi",
-            "version": "==5.2.4"
+            "version": "==5.4.1"
         },
         "six": {
             "hashes": [
-                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
-                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
             ],
-            "version": "==1.13.0"
+            "version": "==1.14.0"
         },
         "wcwidth": {
             "hashes": [
-                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
-                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+                "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1",
+                "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
             ],
-            "version": "==0.1.7"
+            "version": "==0.1.9"
         },
         "zipp": {
             "hashes": [
-                "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e",
-                "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"
+                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
+                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
             ],
-            "version": "==0.6.0"
+            "version": "==3.1.0"
         }
     }
 }

--- a/dbgap_extract.py
+++ b/dbgap_extract.py
@@ -6,6 +6,7 @@ import sys
 from datetime import datetime
 import logging
 import os
+import json
 import queue
 
 FILENAME = "extract-" + datetime.now().strftime("%m-%d-%Y-%H-%M-%S")
@@ -217,7 +218,8 @@ def _get_sra_data_details_from_xml_sample(sample):
         for stat in sra_datas:
             stat_dict = stat.attrib
             sra_data_details.update(stat_dict)
-    return sra_data_details
+    sra_details = json.dumps(sra_data_details).replace('""', '"')
+    return sra_details
 
 
 def get_sample_dict_from_xml_sample(study_accession, sample, args):
@@ -234,9 +236,9 @@ def get_sample_dict_from_xml_sample(study_accession, sample, args):
     """
     sample_dict = sample.attrib
 
-    sample_dict["sample_use"] = [
-        use.text for use in sample.findall("Uses")[0].findall("Use")
-    ]
+    sample_dict["sample_use"] = json.dumps(
+        [use.text for use in sample.findall("Uses")[0].findall("Use")]
+    )
 
     if args.expand_sra_details:
         sample_dict["sra_data_details"] = _get_sra_data_details_from_xml_sample(sample)

--- a/dbgap_extract.py
+++ b/dbgap_extract.py
@@ -158,7 +158,7 @@ def _get_previous_version_of_study_accession(study_accession):
     return previous_version_of_study_accession
 
 
-def get_flattened_sample_use_from_xml_sample(sample):
+def _get_flattened_sample_use_from_xml_sample(sample):
     """
     Get sample use details as a string similar to how it's represented on
     the dbGaP site

--- a/dbgap_extract.py
+++ b/dbgap_extract.py
@@ -176,7 +176,7 @@ def _get_flattened_sra_data_details_from_xml_sample(sample):
         for stat in sra_datas:
             stat_dict = stat.attrib
             stats_as_string = ""
-            for key in stat_dict:
+            for key in {k: stat_dict[k] for k in sorted(stat_dict)}:
                 stats_as_string += key + ":" + stat_dict[key] + "|"
             if stats_as_string[-1] == "|":
                 stats_as_string = stats_as_string[:-1]

--- a/dbgap_extract.py
+++ b/dbgap_extract.py
@@ -159,24 +159,6 @@ def _get_previous_version_of_study_accession(study_accession):
     return previous_version_of_study_accession
 
 
-def _get_flattened_sample_use_from_xml_sample(sample):
-    """
-    Get sample use details as a string similar to how it's represented on
-    the dbGaP site
-
-    Args:
-        sample (xml.etree.ElementTree.Element): sample element from XML tree
-
-    Returns:
-        str: SRA details as a string
-    """
-    uses = sample.findall("Uses")[0].findall("Use")
-    uses_as_string = ""
-    if len(uses) > 0:
-        uses_as_string = "; ".join(list(map(lambda x: x.text, uses)))
-    return uses_as_string
-
-
 def _get_flattened_sra_data_details_from_xml_sample(sample):
     """
     Get SRA details as a string similar to how it's represented on

--- a/dbgap_extract.py
+++ b/dbgap_extract.py
@@ -176,7 +176,7 @@ def _get_flattened_sra_data_details_from_xml_sample(sample):
         for stat in sra_datas:
             stat_dict = stat.attrib
             stats_as_string = ""
-            for key in {k: stat_dict[k] for k in sorted(stat_dict)}:
+            for key in sorted(stat_dict):
                 stats_as_string += key + ":" + stat_dict[key] + "|"
             if stats_as_string[-1] == "|":
                 stats_as_string = stats_as_string[:-1]

--- a/tests.py
+++ b/tests.py
@@ -49,7 +49,7 @@ def test_get_sra_data_details_from_xml_sample():
     )
     assert (
         sra_data_details
-        == "(status:public|experiments:1|runs:3|bases:406977793500|size_Gb:74|experiment_type:WGS|platform:ILLUMINA|center:ABC Fast Track Services) "
+        == "(bases:406977793500|center:ABC Fast Track Services|experiment_type:WGS|experiments:1|platform:ILLUMINA|runs:3|size_Gb:74|status:public) "
     )
 
     sra_data_details = dbgap_extract._get_flattened_sra_data_details_from_xml_sample(
@@ -57,7 +57,7 @@ def test_get_sra_data_details_from_xml_sample():
     )
     assert (
         sra_data_details
-        == "(status:public|experiments:1|runs:2|bases:250660703000|size_Gb:49|experiment_type:WGS|platform:ILLUMINA|center:CDE Fast Track Services) "
+        == "(bases:250660703000|center:CDE Fast Track Services|experiment_type:WGS|experiments:1|platform:ILLUMINA|runs:2|size_Gb:49|status:public) "
     )
 
 
@@ -86,7 +86,7 @@ def test_get_sample_dict_from_xml_sample():
         "analyte_type": "DNA",
         "dbgap_status": "Loaded",
         "sample_use": ["Seq_DNA_SNP_CNV", "WGS"],
-        "sra_data_details": "(status:public|experiments:1|runs:3|bases:406977793500|size_Gb:74|experiment_type:WGS|platform:ILLUMINA|center:ABC Fast Track Services) ",
+        "sra_data_details": "(bases:406977793500|center:ABC Fast Track Services|experiment_type:WGS|experiments:1|platform:ILLUMINA|runs:3|size_Gb:74|status:public) ",
         "study_accession": "phs001234.v3.p1",
         "study_accession_with_consent": "phs001234.v3.p1.c1",
         "study_with_consent": "phs001234.c1",
@@ -113,7 +113,7 @@ def test_get_sample_dict_from_xml_sample():
         "analyte_type": "DNA",
         "dbgap_status": "Loaded",
         "sample_use": ["Seq_DNA_SNP_CWB", "GWS"],
-        "sra_data_details": "(status:public|experiments:1|runs:2|bases:250660703000|size_Gb:49|experiment_type:WGS|platform:ILLUMINA|center:CDE Fast Track Services) ",
+        "sra_data_details": "(bases:250660703000|center:CDE Fast Track Services|experiment_type:WGS|experiments:1|platform:ILLUMINA|runs:2|size_Gb:49|status:public) ",
         "study_accession": "phs001234.v3.p1",
         "study_accession_with_consent": "phs001234.v3.p1.c1",
         "study_with_consent": "phs001234.c1",

--- a/tests.py
+++ b/tests.py
@@ -3,6 +3,7 @@
 
 import sys
 import pytest
+import json
 import filecmp
 import dbgap_extract
 import argparse
@@ -94,6 +95,7 @@ def test_get_sample_dict_from_xml_sample():
     sample_dict = dbgap_extract.get_sample_dict_from_xml_sample(
         "phs001234.v3.p1", sample_elements[0], args
     )
+    sample_dict["sample_use"] = json.loads(sample_dict["sample_use"])
     assert_dict_equality(sample_dict, expected_sample_dict)
 
     expected_sample_dict = {
@@ -120,6 +122,7 @@ def test_get_sample_dict_from_xml_sample():
     sample_dict = dbgap_extract.get_sample_dict_from_xml_sample(
         "phs001234.v3.p1", sample_elements[1], args
     )
+    sample_dict["sample_use"] = json.loads(sample_dict["sample_use"])
     assert_dict_equality(sample_dict, expected_sample_dict)
 
 
@@ -160,6 +163,8 @@ def test_get_sample_dict_sra_expand_from_xml_sample():
     sample_dict = dbgap_extract.get_sample_dict_from_xml_sample(
         "phs001234.v3.p1", sample_elements[0], args
     )
+    sample_dict["sample_use"] = json.loads(sample_dict["sample_use"])
+    sample_dict["sra_data_details"] = json.loads(sample_dict["sra_data_details"])
     assert_dict_equality(sample_dict, expected_sample_dict)
 
     expected_sample_dict = {
@@ -195,4 +200,6 @@ def test_get_sample_dict_sra_expand_from_xml_sample():
     sample_dict = dbgap_extract.get_sample_dict_from_xml_sample(
         "phs001234.v3.p1", sample_elements[1], args
     )
+    sample_dict["sample_use"] = json.loads(sample_dict["sample_use"])
+    sample_dict["sra_data_details"] = json.loads(sample_dict["sra_data_details"])
     assert_dict_equality(sample_dict, expected_sample_dict)

--- a/tests.py
+++ b/tests.py
@@ -5,25 +5,26 @@ import sys
 import pytest
 import filecmp
 import dbgap_extract
+import argparse
 import xml.etree.ElementTree as ET
 
 
 def test_get_previous_version_of_study_accession():
     study_accession = "phs001143.v2.p1"
-    previous_version = dbgap_extract.get_previous_version_of_study_accession(
+    previous_version = dbgap_extract._get_previous_version_of_study_accession(
         study_accession
     )
     assert previous_version == "phs001143.v1.p1"
 
     # Can't go back a version
     study_accession = "phs001143.v1.p1"
-    previous_version = dbgap_extract.get_previous_version_of_study_accession(
+    previous_version = dbgap_extract._get_previous_version_of_study_accession(
         study_accession
     )
     assert previous_version == None
 
     study_accession = "phs000179.v33.p2"
-    previous_version = dbgap_extract.get_previous_version_of_study_accession(
+    previous_version = dbgap_extract._get_previous_version_of_study_accession(
         study_accession
     )
     assert previous_version == "phs000179.v32.p2"
@@ -42,7 +43,7 @@ def get_test_sample_elements():
 def test_get_sra_data_details_from_xml_sample():
     sample_elements = get_test_sample_elements()
 
-    sra_data_details = dbgap_extract.get_sra_data_details_from_xml_sample(
+    sra_data_details = dbgap_extract._get_flattened_sra_data_details_from_xml_sample(
         sample_elements[0]
     )
     assert (
@@ -50,23 +51,13 @@ def test_get_sra_data_details_from_xml_sample():
         == "(status:public|experiments:1|runs:3|bases:406977793500|size_Gb:74|experiment_type:WGS|platform:ILLUMINA|center:ABC Fast Track Services) "
     )
 
-    sra_data_details = dbgap_extract.get_sra_data_details_from_xml_sample(
+    sra_data_details = dbgap_extract._get_flattened_sra_data_details_from_xml_sample(
         sample_elements[1]
     )
     assert (
         sra_data_details
         == "(status:public|experiments:1|runs:2|bases:250660703000|size_Gb:49|experiment_type:WGS|platform:ILLUMINA|center:CDE Fast Track Services) "
     )
-
-
-def test_get_sample_use_from_xml_sample():
-    sample_elements = get_test_sample_elements()
-
-    sample_use = dbgap_extract.get_sample_use_from_xml_sample(sample_elements[0])
-    assert sample_use == "Seq_DNA_SNP_CNV; WGS"
-
-    sample_use = dbgap_extract.get_sample_use_from_xml_sample(sample_elements[1])
-    assert sample_use == "Seq_DNA_SNP_CWB; GWS"
 
 
 def assert_dict_equality(dict_a, dict_b):
@@ -77,6 +68,7 @@ def assert_dict_equality(dict_a, dict_b):
 
 def test_get_sample_dict_from_xml_sample():
     sample_elements = get_test_sample_elements()
+    args = argparse.Namespace(expand_sra_details=False)
 
     expected_sample_dict = {
         "repository": "CDE",
@@ -92,15 +84,15 @@ def test_get_sample_dict_from_xml_sample():
         "body_site": "Whole blood",
         "analyte_type": "DNA",
         "dbgap_status": "Loaded",
-        "sample_use": "Seq_DNA_SNP_CNV; WGS",
+        "sample_use": ["Seq_DNA_SNP_CNV", "WGS"],
         "sra_data_details": "(status:public|experiments:1|runs:3|bases:406977793500|size_Gb:74|experiment_type:WGS|platform:ILLUMINA|center:ABC Fast Track Services) ",
         "study_accession": "phs001234.v3.p1",
         "study_accession_with_consent": "phs001234.v3.p1.c1",
         "study_with_consent": "phs001234.c1",
-        "datastage_subject_id": "phs001234.v3_ABC",
+        "study_subject_id": "phs001234.v3_ABC",
     }
     sample_dict = dbgap_extract.get_sample_dict_from_xml_sample(
-        "phs001234.v3.p1", sample_elements[0]
+        "phs001234.v3.p1", sample_elements[0], args
     )
     assert_dict_equality(sample_dict, expected_sample_dict)
 
@@ -118,14 +110,89 @@ def test_get_sample_dict_from_xml_sample():
         "body_site": "Whole blood",
         "analyte_type": "DNA",
         "dbgap_status": "Loaded",
-        "sample_use": "Seq_DNA_SNP_CWB; GWS",
+        "sample_use": ["Seq_DNA_SNP_CWB", "GWS"],
         "sra_data_details": "(status:public|experiments:1|runs:2|bases:250660703000|size_Gb:49|experiment_type:WGS|platform:ILLUMINA|center:CDE Fast Track Services) ",
         "study_accession": "phs001234.v3.p1",
         "study_accession_with_consent": "phs001234.v3.p1.c1",
         "study_with_consent": "phs001234.c1",
-        "datastage_subject_id": "phs001234.v3_CDE",
+        "study_subject_id": "phs001234.v3_CDE",
     }
     sample_dict = dbgap_extract.get_sample_dict_from_xml_sample(
-        "phs001234.v3.p1", sample_elements[1]
+        "phs001234.v3.p1", sample_elements[1], args
+    )
+    assert_dict_equality(sample_dict, expected_sample_dict)
+
+
+def test_get_sample_dict_sra_expand_from_xml_sample():
+    sample_elements = get_test_sample_elements()
+    args = argparse.Namespace(expand_sra_details=True)
+
+    expected_sample_dict = {
+        "repository": "CDE",
+        "submitted_sample_id": "NWD1",
+        "biosample_id": "SAMN1",
+        "submitted_subject_id": "ABC",
+        "dbgap_sample_id": "1",
+        "dbgap_subject_id": "1",
+        "sra_sample_id": "SRS1",
+        "consent_code": "1",
+        "consent_short_name": "GRU-IRB",
+        "sex": "male",
+        "body_site": "Whole blood",
+        "analyte_type": "DNA",
+        "dbgap_status": "Loaded",
+        "sample_use": ["Seq_DNA_SNP_CNV", "WGS"],
+        "sra_data_details": {
+            "status": "public",
+            "experiments": "1",
+            "runs": "3",
+            "bases": "406977793500",
+            "size_Gb": "74",
+            "experiment_type": "WGS",
+            "platform": "ILLUMINA",
+            "center": "ABC Fast Track Services",
+        },
+        "study_accession": "phs001234.v3.p1",
+        "study_accession_with_consent": "phs001234.v3.p1.c1",
+        "study_with_consent": "phs001234.c1",
+        "study_subject_id": "phs001234.v3_ABC",
+    }
+    sample_dict = dbgap_extract.get_sample_dict_from_xml_sample(
+        "phs001234.v3.p1", sample_elements[0], args
+    )
+    assert_dict_equality(sample_dict, expected_sample_dict)
+
+    expected_sample_dict = {
+        "repository": "FGH",
+        "submitted_sample_id": "NWD1",
+        "biosample_id": "SAMN2",
+        "submitted_subject_id": "CDE",
+        "dbgap_sample_id": "1",
+        "dbgap_subject_id": "2",
+        "sra_sample_id": "SRS2",
+        "consent_code": "1",
+        "consent_short_name": "GRU-IRB",
+        "sex": "female",
+        "body_site": "Whole blood",
+        "analyte_type": "DNA",
+        "dbgap_status": "Loaded",
+        "sample_use": ["Seq_DNA_SNP_CWB", "GWS"],
+        "sra_data_details": {
+            "status": "public",
+            "experiments": "1",
+            "runs": "2",
+            "bases": "250660703000",
+            "size_Gb": "49",
+            "experiment_type": "WGS",
+            "platform": "ILLUMINA",
+            "center": "CDE Fast Track Services",
+        },
+        "study_accession": "phs001234.v3.p1",
+        "study_accession_with_consent": "phs001234.v3.p1.c1",
+        "study_with_consent": "phs001234.c1",
+        "study_subject_id": "phs001234.v3_CDE",
+    }
+    sample_dict = dbgap_extract.get_sample_dict_from_xml_sample(
+        "phs001234.v3.p1", sample_elements[1], args
     )
     assert_dict_equality(sample_dict, expected_sample_dict)

--- a/validate_extract.py
+++ b/validate_extract.py
@@ -57,11 +57,17 @@ def main():
 
     study_accession_list_filename = args.study_accession_list_filename
     dbgap_extract = args.dbgap_extract
-    accessions_from_input = get_unique_accessions_from_input_PHS_list(study_accession_list_filename)
+    accessions_from_input = get_unique_accessions_from_input_PHS_list(
+        study_accession_list_filename
+    )
 
     accessions_from_output = get_unique_accessions_from_output_extract(dbgap_extract)
 
-    print("Looking at input {} vs output {}".format(study_accession_list_filename, dbgap_extract))
+    print(
+        "Looking at input {} vs output {}".format(
+            study_accession_list_filename, dbgap_extract
+        )
+    )
     print("Input: ", accessions_from_input)
     print("Output: ", accessions_from_output)
 


### PR DESCRIPTION
…rse sample use as list, add docstrings


### New Features
- Support CLI param for expanding SRA details to dict instead of string

### Breaking Changes
- parses "sample_use" from dbgap as a list of strings instead of ;-delimited str

### Bug Fixes


### Improvements
- remove datastage references
- add missing docstrings

### Dependency updates


### Deployment changes
