### PR TITLE
chore(qa): Make the dbGaP study API endpoint overridable for testing purposes

### DIFF
--- a/dbgap_extract.py
+++ b/dbgap_extract.py
@@ -10,7 +10,7 @@ import json
 import queue
 
 FILENAME = "extract-" + datetime.now().strftime("%m-%d-%Y-%H-%M-%S")
-REQUEST_URL = "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/GetSampleStatus.cgi?study_id={}&rettype=xml"
+REQUEST_URL = os.environ.get('DBGAP_STUDY_ENDPOINT', 'https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/GetSampleStatus.cgi?study_id={}&rettype=xml')
 LOG_FILE = FILENAME + ".log"
 logging.basicConfig(filename=LOG_FILE, level=logging.DEBUG)
 


### PR DESCRIPTION
To make this component testable, we need to be able to mock the data input to create assertions based on dummy data.

### New Features
- Making the REQUEST_URL constant overridable